### PR TITLE
fix: enforce room membership on the client-to-client relay

### DIFF
--- a/packages/transfer-server/src/JsBridgeE2EEServer.ts
+++ b/packages/transfer-server/src/JsBridgeE2EEServer.ts
@@ -10,6 +10,7 @@ import type {
   IJsBridgeMessagePayload,
   IJsonRpcRequest,
 } from '@onekeyfe/cross-inpage-provider-types';
+import type { RoomManager } from './roomManager';
 import type { Socket } from 'socket.io';
 
 const logger = createModuleLogger('jsBridge');
@@ -94,14 +95,20 @@ function checkBridgePayload(
 export class JsBridgeE2EEServer extends JsBridgeBase {
   constructor(
     config: IJsBridgeConfig,
-    { socketClient }: { socketClient: Socket },
+    {
+      socketClient,
+      roomManager,
+    }: { socketClient: Socket; roomManager: RoomManager },
   ) {
     super(config);
     this.socketClient = socketClient;
+    this.roomManager = roomManager;
     this.setup();
   }
 
   private socketClient: Socket;
+
+  private roomManager: RoomManager;
 
   /**
    * Rate limit state, scoped to this connection rather than kept in a
@@ -427,6 +434,16 @@ export class JsBridgeE2EEServer extends JsBridgeBase {
     const checked = checkBridgePayload(payload, { requireMethod });
     if (!checked.valid) {
       this.logInvalidPayload(eventName, payload, checked.reason);
+      return undefined;
+    }
+
+    // `socket.to(roomId)` is a delivery operator: it reads the membership of the
+    // recipients and never checks the sender's. Without this, any connected
+    // socket that knows a roomId can inject client-to-client calls into a room
+    // it never joined - bypassing the room-slot invariant the pairing flow
+    // relies on. Membership is authoritative in RoomManager, so ask it.
+    if (!this.roomManager.isUserInRoom(roomId, this.socketClient.id).isInRoom) {
+      this.logInvalidPayload(eventName, payload, 'sender is not a room member');
       return undefined;
     }
 

--- a/packages/transfer-server/src/JsBridgeE2EEServer.ts
+++ b/packages/transfer-server/src/JsBridgeE2EEServer.ts
@@ -47,9 +47,27 @@ const CLIENT_TO_CLIENT_RATE_LIMIT_ERROR_CODE = -387_155_488;
 // Rate limiting whitelist - methods that are exempt from rate limiting
 const RATE_LIMIT_WHITELIST = new Set([
   'changeTransferDirection',
-  'getRoomUsers',
   'leaveRoom',
   'cancelTransfer',
+]);
+
+/**
+ * Per-method rate limit windows, overriding RATE_LIMIT_INTERVAL_MS.
+ *
+ * getRoomUsers is polled by the CLI once per second while pairing, so the
+ * default 3s window would reject two of every three polls. It was previously
+ * exempt from rate limiting altogether, which let it be called at line speed.
+ *
+ * The window must stay meaningfully below the caller's polling interval:
+ * setInterval fixes the interval at which requests are *sent*, and network
+ * latency shifts every request by roughly the same amount, so it cancels out
+ * of the gap the server sees. Only jitter moves that gap, in both directions.
+ * A 1000ms window against a 1000ms poll therefore sits exactly on the
+ * threshold - measured over localhost, where latency is under a millisecond
+ * and stable, timer drift alone still pushed one poll in 30 below it.
+ */
+const METHOD_RATE_LIMIT_INTERVAL_MS = new Map<string, number>([
+  ['getRoomUsers', 800],
 ]);
 
 const SUPPORTED_MESSAGE_TYPES: ReadonlySet<string> = new Set([
@@ -264,8 +282,10 @@ export class JsBridgeE2EEServer extends JsBridgeBase {
 
     const now = Date.now();
     const lastTime = this.rateLimitState.get(rateLimitKey);
+    const interval =
+      METHOD_RATE_LIMIT_INTERVAL_MS.get(method) ?? RATE_LIMIT_INTERVAL_MS;
 
-    if (lastTime !== undefined && now - lastTime < RATE_LIMIT_INTERVAL_MS) {
+    if (lastTime !== undefined && now - lastTime < interval) {
       sendErrorResponse();
       return true;
     }
@@ -305,7 +325,14 @@ export class JsBridgeE2EEServer extends JsBridgeBase {
    */
   private pruneRateLimitState(now: number): void {
     for (const [key, time] of this.rateLimitState) {
-      if (now - time >= RATE_LIMIT_INTERVAL_MS) {
+      // Expire each entry against its own window, not the default one: a
+      // per-method window longer than the default would otherwise be dropped
+      // while still live, which is exactly the rate limit reset this function
+      // is written to prevent.
+      const method = key.slice(key.indexOf(':') + 1);
+      const interval =
+        METHOD_RATE_LIMIT_INTERVAL_MS.get(method) ?? RATE_LIMIT_INTERVAL_MS;
+      if (now - time >= interval) {
         this.rateLimitState.delete(key);
       }
     }

--- a/packages/transfer-server/src/JsBridgeE2EEServer.ts
+++ b/packages/transfer-server/src/JsBridgeE2EEServer.ts
@@ -54,19 +54,33 @@ const RATE_LIMIT_WHITELIST = new Set([
 /**
  * Per-method rate limit windows, overriding RATE_LIMIT_INTERVAL_MS.
  *
- * getRoomUsers is polled by the CLI once per second while pairing, so the
- * default 3s window would reject two of every three polls. It was previously
- * exempt from rate limiting altogether, which let it be called at line speed.
+ * This table is for legitimate high-frequency callers that a shipped client
+ * already depends on. It is not a way to opt out of rate limiting: a method
+ * absent from here is limited at RATE_LIMIT_INTERVAL_MS, and that default is
+ * the point - a newly added method is protected without anyone having to
+ * remember to protect it.
  *
- * The window must stay meaningfully below the caller's polling interval:
- * setInterval fixes the interval at which requests are *sent*, and network
- * latency shifts every request by roughly the same amount, so it cancels out
- * of the gap the server sees. Only jitter moves that gap, in both directions.
- * A 1000ms window against a 1000ms poll therefore sits exactly on the
- * threshold - measured over localhost, where latency is under a millisecond
- * and stable, timer drift alone still pushed one poll in 30 below it.
+ * Adding an entry means stating, on that entry, which caller needs it, at what
+ * frequency, and why the default window cannot serve it. An entry is a
+ * compatibility shim and has a lifetime: remove it once its caller no longer
+ * needs it, rather than leaving a permanent hole behind.
+ *
+ * A window also has to stay meaningfully below the caller's polling interval.
+ * setInterval fixes the interval at which requests are *sent*; network latency
+ * shifts every request by roughly the same amount, so it cancels out of the gap
+ * the server observes, and only jitter moves that gap - in both directions. A
+ * 1000ms window against a 1000ms poll therefore sits exactly on the threshold
+ * rather than safely above it: measured over localhost, where latency is under
+ * a millisecond and stable, timer drift alone still pushed one poll in 30 below
+ * it and into a rejection.
  */
 const METHOD_RATE_LIMIT_INTERVAL_MS = new Map<string, number>([
+  // CLI, once per second for the whole pairing phase
+  // (ROOM_USERS_POLL_INTERVAL_MS in transfer-receiver-adapter.ts): it had no
+  // user-joined push to wait on, so it polls to notice a peer arriving. The
+  // default 3s window would reject two of every three polls. Remove this entry
+  // once the CLI consumes the user-joined event instead - the poll and this
+  // shim go together.
   ['getRoomUsers', 800],
 ]);
 

--- a/packages/transfer-server/src/e2eeServerApi.ts
+++ b/packages/transfer-server/src/e2eeServerApi.ts
@@ -70,6 +70,7 @@ function createBridgeE2EEServer({
     },
     {
       socketClient,
+      roomManager,
     },
   );
 }

--- a/packages/transfer-server/src/roomManager.ts
+++ b/packages/transfer-server/src/roomManager.ts
@@ -202,6 +202,20 @@ export class RoomManager {
 
     await context?.socketClient.join(roomId);
 
+    // Tell the members already in the room that someone joined. The server
+    // never pushed this before, so a peer that needed to know had to poll
+    // getRoomUsers instead - which is why that method carries a high call rate.
+    //
+    // Emitted from the joining socket rather than the server, so the joiner is
+    // excluded (it does not need to be told about itself), and only after
+    // join() resolves, so the membership the event describes is already in
+    // effect if a receiver immediately calls getRoomUsers.
+    context?.socketClient.to(roomId).emit("user-joined", {
+      roomId,
+      userId,
+      userCount: room.users.size,
+    });
+
     return {
       success: true,
       userId,

--- a/packages/transfer-server/src/roomManager.ts
+++ b/packages/transfer-server/src/roomManager.ts
@@ -46,6 +46,17 @@ export class RoomManager {
   /**
    * Create new room
    * @returns Room information (room ID and encryption key)
+   *
+   * NOTE on `encryptionKey` (returned here and as `roomKey` from joinRoom):
+   * this key is NOT used by the OneKey client, and it is not what protects
+   * transferred data. The client derives its own end-to-end key locally from
+   * material this server never sees - the pairing code shown in the QR code
+   * (only its roomId prefix ever reaches the server), an ECDHE shared secret
+   * negotiated directly between the two devices, and the room's user list.
+   * A malicious or compromised server therefore still cannot decrypt anything,
+   * because it holds none of that material. This server never encrypts or
+   * decrypts payloads with this key either - it only relays them. The field is
+   * kept for wire compatibility with existing clients.
    */
   @e2eeApiMethod()
   async createRoom(): Promise<{ roomId: string; encryptionKey: string }> {
@@ -101,6 +112,11 @@ export class RoomManager {
    * @param encryptionKey Encryption key
    * @param socketId User's Socket ID
    * @returns Join result
+   *
+   * The returned `roomKey` is server-generated and unused by the client - see
+   * the note on createRoom(). It is not part of the end-to-end encryption
+   * scheme; the client derives its own key from the pairing code and an ECDHE
+   * exchange this server is not party to.
    */
   @e2eeApiMethod()
   async joinRoom(

--- a/packages/transfer-server/src/roomManager.ts
+++ b/packages/transfer-server/src/roomManager.ts
@@ -326,18 +326,26 @@ export class RoomManager {
       );
     }
     logger.debug({ roomId }, "room.getRoomUsers");
-    const room = this.rooms.get(roomId);
-    if (!room) {
-      logger.debug({ roomId }, "room.getRoomUsersNotFound");
-      return [];
-    }
-    // Validate that the socket is in the room
+
+    // A room the caller cannot see must be indistinguishable from a room that
+    // does not exist. Returning [] for a missing room while throwing for a room
+    // the caller is not in turned this into a room existence oracle - and this
+    // method is exempt from rate limiting, so it could be probed at line speed.
+    // isUserInRoom() already reports false for a missing room, so both cases
+    // fail here identically, with the same error code and message.
     const socketValidation = this.isUserInRoom(roomId, context.socketClient.id);
     if (!socketValidation.isInRoom) {
-      throw new E2eeError(
-        E2eeErrorCode.SOCKET_NOT_IN_ROOM,
-        "Socket must be in the room to set transfer direction"
+      logger.debug(
+        { roomId, roomExists: this.rooms.has(roomId) },
+        "room.getRoomUsersDenied"
       );
+      throw new E2eeError(E2eeErrorCode.ROOM_NOT_FOUND, "Room not found");
+    }
+
+    // isInRoom implies the room exists.
+    const room = this.rooms.get(roomId);
+    if (!room) {
+      throw new E2eeError(E2eeErrorCode.ROOM_NOT_FOUND, "Room not found");
     }
 
     const users: IE2EESocketUserInfo[] = sortBy(

--- a/packages/transfer-server/src/types.ts
+++ b/packages/transfer-server/src/types.ts
@@ -8,8 +8,19 @@ export { E2eeError, E2eeErrorCode } from './errors';
 export interface IServerToClientEvents {
   'room-created': (data: { roomId: string; encryptionKey: string }) => void;
   'room-joined': (data: { roomId: string; userId: string }) => void;
-  'user-joined': (data: { userId: string; userCount: number }) => void;
-  'user-left': (data: { userId: string; userCount: number }) => void;
+  // roomId is part of both payloads: a client multiplexes every room over one
+  // socket, so it needs to tell which room an event refers to. `user-left` has
+  // always been emitted with it - the declaration was simply out of date.
+  'user-joined': (data: {
+    roomId: string;
+    userId: string;
+    userCount: number;
+  }) => void;
+  'user-left': (data: {
+    roomId: string;
+    userId: string;
+    userCount: number;
+  }) => void;
   'encrypted-data': (data: {
     encryptedData: string;
     senderId: string;

--- a/packages/transfer-server/src/types.ts
+++ b/packages/transfer-server/src/types.ts
@@ -48,6 +48,11 @@ export interface ISocketData {
 // Room data structure
 export interface IRoom {
   id: string;
+  // Server-generated key handed to clients on create/join. The OneKey client
+  // does not consume it, and this server never encrypts with it - payloads are
+  // relayed as-is. Real end-to-end protection comes from a key the clients
+  // derive themselves (pairing code + ECDHE shared secret + room user list),
+  // none of which this server holds. See RoomManager.createRoom().
   encryptionKey: string;
   users: Map<string, IE2EESocketUserInfo>;
   transferDirection?:


### PR DESCRIPTION
Prompted by an external security report claiming the server-returned room
key defeats E2EE. That claim does not hold — the key is never consumed by
any client and this server never encrypts with it — but auditing it turned
up two real gaps and one piece of missing infrastructure.

## What changed

**1. The c2c relay never checked the sender's membership** (`943a287`)

`socket.to(roomId).emit()` resolves the membership of the *recipients* and
never checks the sender's. Both relay paths passed a client-supplied roomId
straight into it, so any connected socket that knew a roomId could inject
client-to-client calls into a room it had never joined — without taking a
room slot, without raising `room-full`, and invisibly to both real devices.

That bypassed the invariant the pairing flow relies on: influencing a
session should require occupying one of the two slots, which is exactly
what makes it observable (the real device can no longer join, so the user
re-pairs with a fresh room).

Reproduced against the built server: with A and B paired 2/2 — join refused
with `CONNECTION_REJECTED`, member list holding only A and B — a third
socket that never joined still delivered `cancelTransfer` to both.

Impact was availability only, never confidentiality: payloads are encrypted
with a key the clients derive from the pairing code and an ECDHE exchange
this server is not party to.

**2. `getRoomUsers` leaked room existence** (`8d6a778`)

It returned `[]` for a missing room but threw for a room the caller was not
in, so any socket could tell the two apart — an unauthenticated room
existence oracle, and one exempt from rate limiting, measured at ~1250
probes/s. Both cases now fail identically through `isUserInRoom()`.

Uses `ROOM_NOT_FOUND` rather than `SOCKET_NOT_IN_ROOM` because clients map
error codes, not messages: shipped clients already translate the former
into a localized prompt, while the latter surfaces a raw English string.

**3. `getRoomUsers` is rate limited instead of exempt** (`cbea719`)

It was whitelisted because the CLI polls it once per second while pairing.
It now has its own 800ms window: the CLI's poll is unaffected and the
ceiling drops to ~1.25 calls/s per connection.

The window must sit meaningfully below the caller's poll interval —
`setInterval` fixes when requests are *sent*, and latency cancels out of
the gap the server sees, so only jitter moves it, in both directions. A
1000ms window against a 1000ms poll sits exactly on the threshold: over
localhost, timer drift alone still pushed one poll in 30 into a rejection.
At 800ms the same run passes 30 of 30.

`pruneRateLimitState()` now expires each entry against its own window, so a
per-method window longer than the default cannot be reclaimed while live —
precisely the rate limit reset that function exists to prevent.

**4. The server now emits `user-joined`** (`912bdc9`)

Declared in `IServerToClientEvents` since the beginning but never emitted,
which is why the CLI polls to notice a peer arriving. Emitted from the
joining socket (so the joiner is excluded) after `join()` resolves (so the
membership it describes is already in effect).

Inert for now: no shipped client registers a handler, and Socket.IO drops
events with none. The 800ms window has to stay until the CLI's poll is
actually gone.

**5. Documentation** (`943a287`, `b0bda66`)

The room key's semantics are now stated at each site it surfaces — clients
never consume it, this server never encrypts with it, and real protection
comes from a key derived on the clients. Reviewers have read it as key
escrow; the intent should not require an audit to recover.

The per-method rate limit table now states its contract: it is for
legitimate high-frequency callers, not an opt-out. Absent methods fall back
to the default, and that default is the point — a new method is limited
without anyone having to remember to limit it.

## Verification

Every commit was built and run against `smoke.ts` + `crash-logging.ts`
(all pass), plus targeted checks against the built server:

- non-member injection blocked on both c2c paths; member-to-member traffic
  unaffected
- existing and missing rooms return byte-identical errors to a non-member
- default 3s limit still applies to unknown/new methods (verified with a
  method name the server does not implement), whitelist still exempt,
  `getRoomUsers` limited at 100ms and passing at 900ms
- `user-joined` reaches existing members only, with the joiner excluded, and
  membership is already visible to a receiver that immediately calls
  `getRoomUsers`

## Follow-ups in the client repo

1. CLI: consume `user-joined` instead of polling `getRoomUsers`
   (`transfer-receiver-adapter.ts`). Once shipped, the `getRoomUsers` entry
   in the rate limit table can be deleted.
2. `cancelTransfer` on the client c2c API has no guard at all — it does not
   compare roomId, nor check whether pairing was verified. It should use the
   existing `checkIsVerifiedRoomId()`, as should `changeTransferDirection`.
   That check can only live on the client: this server does not know, and
   should not know, whether pairing succeeded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)